### PR TITLE
Feat/bug panic by type of atomicerr #26

### DIFF
--- a/internal/runner/error.go
+++ b/internal/runner/error.go
@@ -1,0 +1,5 @@
+package runner
+
+type syncError struct {
+	Err error
+}


### PR DESCRIPTION
### Description
Fix Panic on AtomicErr

- Fixed Err Output
  ``` bash
  Terminate BaseExecutor.Execute: filename=sc/sc1.yaml, outputRoot=20250114_172653, index=0, callCount=0
  Failed to run the load test: failed to execute the load test: failed to execute flow: failed to execute flow: failed to execute flow: failed to find slave: slave1
  ```

### Related Issue
Closes #26 

### How Has This Been Tested?
Manual testing due to lack of test code

### Checklist
- [x] I have formatted the code using `gofumpt -extra`.
- [x] I have run `goimports -local github.com/cresplanex/bloader`.
- [x] I have run `golangci-lint` and resolved all issues.
- [x] I have tested the code with `gotestsum`.
- [x] I have check `lint`, `format`, and `breaking` on proto buffer.
- [x] Documentation has been updated if necessary.
